### PR TITLE
ci: log confirmation when securehst is auto-assigned

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -30,6 +30,7 @@ jobs:
             if (!number) return;
             try {
               await github.rest.issues.addAssignees({ owner, repo, issue_number: number, assignees: ASSIGNEES });
+              core.info(`Assigned [${ASSIGNEES.join(", ")}] to #${number}`);
             } catch (err) {
               core.warning(`Could not assign [${ASSIGNEES.join(", ")}] to #${number}: ${err.message}`);
             }


### PR DESCRIPTION
## What

Adds one `core.info` line to the **Auto Assign** workflow so each run logs the assignment it performed:

```js
await github.rest.issues.addAssignees({ owner, repo, issue_number: number, assignees: ASSIGNEES });
core.info(`Assigned [${ASSIGNEES.join(", ")}] to #${number}`);
```

## Why

On the success path, `issues.addAssignees` produces no output, so a **working** run looks empty in the Actions log — only the input-echo header is visible. This adds a confirmation line (`Assigned [securehst] to #N`) so runs are self-documenting and easy to confirm at a glance.

No behavior change — logging only. Assignment failures still surface via the existing `core.warning` in the `catch`.

## Verification

The auto-assign mechanism is already confirmed working (e.g. `insights` #9, opened after the workflow landed → `securehst` assigned). This PR only improves observability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
